### PR TITLE
Fix gcc warnings in fasthash-sys

### DIFF
--- a/fasthash-sys/build.rs
+++ b/fasthash-sys/build.rs
@@ -49,7 +49,7 @@ fn generate_binding(out_file: &Path) {
 }
 
 fn main() {
-    let mut gcc_config = gcc::Config::new();
+    let mut gcc_config = gcc::Build::new();
 
     gcc_config
         .file("src/fasthash.cpp")

--- a/fasthash-sys/build.rs
+++ b/fasthash-sys/build.rs
@@ -52,6 +52,7 @@ fn main() {
     let mut gcc_config = gcc::Build::new();
 
     gcc_config
+        .flag("-Wno-implicit-fallthrough")
         .file("src/fasthash.cpp")
         .file("src/smhasher/City.cpp")
         .file("src/smhasher/farmhash-c.c")


### PR DESCRIPTION
Here are some minor updates to avoid some build warnings observed in the form:

~~~
warning: use of deprecated item 'gcc::Config': gcc::Config has been renamed to gcc::Build

warning: this statement may fall through...
~~~
