### PR TITLE
Constrain extprim crate dep until all deps update to rand 0.4+

### DIFF
--- a/fasthash/Cargo.toml
+++ b/fasthash/Cargo.toml
@@ -18,7 +18,7 @@ sse42 = ["fasthash-sys/sse42"]
 gen = ["fasthash-sys/gen"]
 
 [dependencies]
-extprim = "1.1"
+extprim = ">=1.1, <1.5"
 rand = "^0.3"
 xoroshiro128 = "0.2"
 seahash = "3.0"


### PR DESCRIPTION
This a temporary workaround for #6. Until all (transitive) deps can use rand 0.4+, fix the build by constraining the version of extprim to be < 1.5.0.


