### PR TITLE
Derive clone

### DIFF
--- a/fasthash/src/city.rs
+++ b/fasthash/src/city.rs
@@ -137,6 +137,7 @@ use hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 3366460263);
 /// assert_eq!(Hash32::hash(b"helloworld"), 4037657980);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -195,6 +196,7 @@ assert_eq!(h.finish(), 4037657980);
 /// );
 /// assert_eq!(Hash64::hash(b"helloworld"), 16622738483577116029);
 /// ```
+#[derive(Clone)]
 pub struct Hash64;
 
 impl Hash64 {
@@ -278,6 +280,7 @@ assert_eq!(h.finish(), 16622738483577116029);
 ///     137438709495761624905137796394169174828
 /// );
 /// ```
+#[derive(Clone)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {
@@ -356,6 +359,7 @@ pub mod crc {
     /// );
     /// ```
 
+    #[derive(Clone)]
     pub struct Hash128;
 
     impl FastHash for Hash128 {

--- a/fasthash/src/farm.rs
+++ b/fasthash/src/farm.rs
@@ -135,6 +135,7 @@ use hasher::{FastHash, Fingerprint};
 /// assert_eq!(Hash32::hash_with_seed(b"world", 123), 60914537);
 /// assert_eq!(Hash32::hash(b"helloworld"), 2214725017);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -198,6 +199,7 @@ assert_eq!(h.finish(), 2214725017);
 /// );
 /// assert_eq!(Hash64::hash(b"helloworld"), 1077737941828767314);
 /// ```
+#[derive(Clone)]
 pub struct Hash64;
 
 impl Hash64 {
@@ -279,6 +281,7 @@ assert_eq!(h.finish(), 1077737941828767314);
 ///     296377541162803340912737385112946231361
 /// );
 /// ```
+#[derive(Clone)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {

--- a/fasthash/src/hasher.rs
+++ b/fasthash/src/hasher.rs
@@ -223,6 +223,7 @@ impl From<Seed> for u128 {
 /// assert_eq!(map.insert(37, "c"), Some("b"));
 /// assert_eq!(map[&37], "c");
 /// ```
+#[derive(Clone)]
 pub struct RandomState<T: FastHash> {
     seed: Seed,
     phantom: PhantomData<T>,

--- a/fasthash/src/lookup3.rs
+++ b/fasthash/src/lookup3.rs
@@ -40,6 +40,7 @@ use hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 632258402);
 /// assert_eq!(Hash32::hash(b"helloworld"), 1392336737);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {

--- a/fasthash/src/metro.rs
+++ b/fasthash/src/metro.rs
@@ -56,6 +56,7 @@ use hasher::FastHash;
 /// assert_eq!(Hash64_1::hash_with_seed(b"hello", 123), 1128464039211059189);
 /// assert_eq!(Hash64_1::hash(b"helloworld"), 4615394705531318333);
 /// ```
+#[derive(Clone)]
 pub struct Hash64_1;
 
 impl FastHash for Hash64_1 {
@@ -112,6 +113,7 @@ assert_eq!(h.finish(), 4615394705531318333);
 /// assert_eq!(Hash64_2::hash_with_seed(b"hello", 123), 5558499743061241201);
 /// assert_eq!(Hash64_2::hash(b"helloworld"), 13816693401637061492);
 /// ```
+#[derive(Clone)]
 pub struct Hash64_2;
 
 impl FastHash for Hash64_2 {
@@ -177,6 +179,7 @@ assert_eq!(h.finish(), 13816693401637061492);
 ///     168124756093089300765778527570074281113
 /// );
 /// ```
+#[derive(Clone)]
 pub struct Hash128_1;
 
 impl FastHash for Hash128_1 {
@@ -242,6 +245,7 @@ assert_eq!(h.finish_ext(), 168124756093089300765778527570074281113);
 ///     296295343271043311657399689121923046467
 /// );
 /// ```
+#[derive(Clone)]
 pub struct Hash128_2;
 
 impl FastHash for Hash128_2 {
@@ -306,6 +310,7 @@ pub mod crc {
     /// );
     /// assert_eq!(Hash64_1::hash(b"helloworld"), 15512397028293617890);
     /// ```
+    #[derive(Clone)]
     pub struct Hash64_1;
 
     impl FastHash for Hash64_1 {
@@ -365,6 +370,7 @@ assert_eq!(h.finish(), 15512397028293617890);
     /// );
     /// assert_eq!(Hash64_2::hash(b"helloworld"), 11309399771810154329);
     /// ```
+    #[derive(Clone)]
     pub struct Hash64_2;
 
     impl FastHash for Hash64_2 {
@@ -430,6 +436,7 @@ assert_eq!(h.finish(), 11309399771810154329);
     ///     330807979290440384643858402038145360287
     /// );
     /// ```
+    #[derive(Clone)]
     pub struct Hash128_1;
 
     impl FastHash for Hash128_1 {
@@ -495,6 +502,7 @@ assert_eq!(h.finish_ext(), 330807979290440384643858402038145360287);
     ///     332348429832512530891646387991260171468
     /// );
     /// ```
+    #[derive(Clone)]
     pub struct Hash128_2;
 
     impl FastHash for Hash128_2 {

--- a/fasthash/src/mum.rs
+++ b/fasthash/src/mum.rs
@@ -70,6 +70,7 @@ use hasher::FastHash;
 /// assert_eq!(Hash64::hash_with_seed(b"hello", 123), 12693953100868515521);
 /// assert_eq!(Hash64::hash(b"helloworld"), 9122204010978352975);
 /// ```
+#[derive(Clone)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {

--- a/fasthash/src/murmur.rs
+++ b/fasthash/src/murmur.rs
@@ -57,6 +57,7 @@ use hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2155802495);
 /// assert_eq!(Hash32::hash(b"helloworld"), 567127608);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -108,6 +109,7 @@ assert_eq!(h.finish(), 567127608);
 /// assert_eq!(Hash32Aligned::hash_with_seed(b"hello", 123), 2155802495);
 /// assert_eq!(Hash32Aligned::hash(b"helloworld"), 567127608);
 /// ```
+#[derive(Clone)]
 pub struct Hash32Aligned;
 
 impl FastHash for Hash32Aligned {

--- a/fasthash/src/murmur2.rs
+++ b/fasthash/src/murmur2.rs
@@ -81,6 +81,7 @@ use hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2385981934);
 /// assert_eq!(Hash32::hash(b"helloworld"), 2155944146);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -132,6 +133,7 @@ assert_eq!(h.finish(), 2155944146);
 /// assert_eq!(Hash32A::hash_with_seed(b"hello", 123), 509510832);
 /// assert_eq!(Hash32A::hash(b"helloworld"), 403945221);
 /// ```
+#[derive(Clone)]
 pub struct Hash32A;
 
 impl FastHash for Hash32A {
@@ -183,6 +185,7 @@ assert_eq!(h.finish(), 403945221);
 /// assert_eq!(Hash32Neutral::hash_with_seed(b"hello", 123), 2385981934);
 /// assert_eq!(Hash32Neutral::hash(b"helloworld"), 2155944146);
 /// ```
+#[derive(Clone)]
 pub struct Hash32Neutral;
 
 impl FastHash for Hash32Neutral {
@@ -234,6 +237,7 @@ assert_eq!(h.finish(), 2155944146);
 /// assert_eq!(Hash32Aligned::hash_with_seed(b"hello", 123), 2385981934);
 /// assert_eq!(Hash32Aligned::hash(b"helloworld"), 2155944146);
 /// ```
+#[derive(Clone)]
 pub struct Hash32Aligned;
 
 impl FastHash for Hash32Aligned {
@@ -288,6 +292,7 @@ assert_eq!(h.finish(), 2155944146);
 /// );
 /// assert_eq!(Hash64_x64::hash(b"helloworld"), 2139823713852166039);
 /// ```
+#[derive(Clone)]
 pub struct Hash64_x64;
 
 impl FastHash for Hash64_x64 {
@@ -342,6 +347,7 @@ assert_eq!(h.finish(), 2139823713852166039);
 /// );
 /// assert_eq!(Hash64_x86::hash(b"helloworld"), 14017254558097603378);
 /// ```
+#[derive(Clone)]
 pub struct Hash64_x86;
 
 impl FastHash for Hash64_x86 {

--- a/fasthash/src/murmur3.rs
+++ b/fasthash/src/murmur3.rs
@@ -47,6 +47,7 @@ use hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 1573043710);
 /// assert_eq!(Hash32::hash(b"helloworld"), 2687965642);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -112,6 +113,7 @@ assert_eq!(h.finish(), 2687965642);
 ///     83212725615010754952022132390053357814
 /// );
 /// ```
+#[derive(Clone)]
 pub struct Hash128_x86;
 
 impl FastHash for Hash128_x86 {
@@ -177,6 +179,7 @@ assert_eq!(h.finish_ext(), 83212725615010754952022132390053357814);
 ///     216280293825344914020777844322685271162
 /// );
 /// ```
+#[derive(Clone)]
 pub struct Hash128_x64;
 
 impl FastHash for Hash128_x64 {

--- a/fasthash/src/sea.rs
+++ b/fasthash/src/sea.rs
@@ -45,6 +45,7 @@ use hasher::{FastHash, FastHasher, StreamHasher};
 /// );
 /// assert_eq!(Hash64::hash(b"helloworld"), 9532038143498849405);
 /// ```
+#[derive(Clone)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {

--- a/fasthash/src/spooky.rs
+++ b/fasthash/src/spooky.rs
@@ -62,6 +62,7 @@ use hasher::{FastHash, FastHasher, HasherExt, StreamHasher};
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2211835972);
 /// assert_eq!(Hash32::hash(b"helloworld"), 3874077464);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -119,6 +120,7 @@ assert_eq!(h.finish(), 3874077464);
 /// assert_eq!(Hash64::hash_with_seed(b"hello", 123), 8819086853393477700);
 /// assert_eq!(Hash64::hash(b"helloworld"), 18412934266828208920);
 /// ```
+#[derive(Clone)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {
@@ -185,6 +187,7 @@ assert_eq!(h.finish(), 18412934266828208920);
 ///     339658686066216790682429200470429822413
 /// );
 /// ```
+#[derive(Clone)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {
@@ -226,6 +229,7 @@ impl FastHash for Hash128 {
 /// h.write(b"world");
 /// assert_eq!(h.finish_ext(), 339658686066216790682429200470429822413);
 /// ```
+#[derive(Clone)]
 pub struct Hasher128(*mut c_void);
 
 impl Default for Hasher128 {

--- a/fasthash/src/t1ha.rs
+++ b/fasthash/src/t1ha.rs
@@ -82,6 +82,7 @@ pub mod t1ha2 {
     ///     15302361616348747620
     /// );
     /// ```
+    #[derive(Clone)]
     pub struct Hash64AtOnce;
 
     impl FastHash for Hash64AtOnce {
@@ -142,6 +143,7 @@ assert_eq!(h.finish(), 15302361616348747620);
     ///     315212713565720527393405448145758944961
     /// );
     /// ```
+    #[derive(Clone)]
     pub struct Hash128AtOnce;
 
     impl FastHash for Hash128AtOnce {
@@ -227,6 +229,7 @@ pub mod t1ha1 {
     /// );
     /// assert_eq!(Hash64Le::hash(b"helloworld"), 16997942636322422782);
     /// ```
+    #[derive(Clone)]
     pub struct Hash64Le;
 
     impl FastHash for Hash64Le {
@@ -281,6 +284,7 @@ assert_eq!(h.finish(), 16997942636322422782);
     /// );
     /// assert_eq!(Hash64Be::hash(b"helloworld"), 15825971635414726702);
     /// ```
+    #[derive(Clone)]
     pub struct Hash64Be;
 
     impl FastHash for Hash64Be {
@@ -360,6 +364,7 @@ pub mod t1ha0 {
     /// );
     /// assert_eq!(Hash64::hash(b"helloworld"), 15302361616348747620);
     /// ```
+    #[derive(Clone)]
     pub struct Hash64;
 
     impl FastHash for Hash64 {
@@ -419,6 +424,7 @@ assert_eq!(h.finish(), 15302361616348747620);
         /// );
         /// assert_eq!(Hash64::hash(b"helloworld"), 15302361616348747620);
         /// ```
+        #[derive(Clone)]
         pub struct Hash64;
 
         impl FastHash for Hash64 {
@@ -459,6 +465,7 @@ assert_eq!(h.finish(), 15302361616348747620);
         /// );
         /// assert_eq!(Hash64::hash(b"helloworld"), 15302361616348747620);
         /// ```
+        #[derive(Clone)]
         pub struct Hash64;
 
         impl FastHash for Hash64 {
@@ -499,6 +506,7 @@ assert_eq!(h.finish(), 15302361616348747620);
         /// );
         /// assert_eq!(Hash64::hash(b"helloworld"), 15302361616348747620);
         /// ```
+        #[derive(Clone)]
         pub struct Hash64;
 
         impl FastHash for Hash64 {

--- a/fasthash/src/xx.rs
+++ b/fasthash/src/xx.rs
@@ -46,6 +46,7 @@ use hasher::{FastHash, FastHasher, StreamHasher};
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2147069998);
 /// assert_eq!(Hash32::hash(b"helloworld"), 593682946);
 /// ```
+#[derive(Clone)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -75,6 +76,7 @@ impl FastHash for Hash32 {
 /// assert_eq!(Hash64::hash_with_seed(b"hello", 123), 2900467397628653179);
 /// assert_eq!(Hash64::hash(b"helloworld"), 9228181307863624271);
 /// ```
+#[derive(Clone)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {
@@ -140,6 +142,7 @@ pub fn hash64_with_seed<T: AsRef<[u8]>>(v: T, seed: u64) -> u64 {
 /// h.write_stream(&mut Cursor::new(&[0_u8; 4567][..])).unwrap();
 /// assert_eq!(h.finish(), 2113960620);
 /// ```
+#[derive(Clone)]
 pub struct Hasher32(*mut ffi::XXH32_state_t);
 
 impl Default for Hasher32 {
@@ -211,6 +214,7 @@ impl_fasthash!(Hasher32, Hash32);
 /// h.write_stream(&mut Cursor::new(&[0_u8; 4567][..])).unwrap();
 /// assert_eq!(h.finish(), 6304142433100597454);
 /// ```
+#[derive(Clone)]
 pub struct Hasher64(*mut ffi::XXH64_state_t);
 
 impl Default for Hasher64 {


### PR DESCRIPTION
Because one might want to clone a HashMap for example.