### PR TITLE
Derive default

### DIFF
--- a/fasthash/src/city.rs
+++ b/fasthash/src/city.rs
@@ -137,7 +137,7 @@ use crate::hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 3366460263);
 /// assert_eq!(Hash32::hash(b"helloworld"), 4037657980);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -193,7 +193,7 @@ trivial_hasher! {
 /// );
 /// assert_eq!(Hash64::hash(b"helloworld"), 16622738483577116029);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl Hash64 {
@@ -274,7 +274,7 @@ trivial_hasher! {
 ///     137438709495761624905137796394169174828
 /// );
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {
@@ -350,7 +350,7 @@ pub mod crc {
     /// );
     /// ```
 
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash128;
 
     impl FastHash for Hash128 {

--- a/fasthash/src/farm.rs
+++ b/fasthash/src/farm.rs
@@ -135,7 +135,7 @@ use crate::hasher::{FastHash, Fingerprint};
 /// assert_eq!(Hash32::hash_with_seed(b"world", 123), 60914537);
 /// assert_eq!(Hash32::hash(b"helloworld"), 2214725017);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -196,7 +196,7 @@ trivial_hasher! {
 /// );
 /// assert_eq!(Hash64::hash(b"helloworld"), 1077737941828767314);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl Hash64 {
@@ -275,7 +275,7 @@ trivial_hasher! {
 ///     296377541162803340912737385112946231361
 /// );
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {

--- a/fasthash/src/highway.rs
+++ b/fasthash/src/highway.rs
@@ -108,7 +108,7 @@ pub fn hash128_with_seed<T: AsRef<[u8]>>(v: T, seed: Seed) -> u128 {
 ///
 /// assert_eq!(highway::Hash64::hash_with_seed("hello world", [1, 2, 3, 4]), 6273970844710122614);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {
@@ -160,7 +160,7 @@ trivial_hasher! {
 ///
 /// assert_eq!(highway::Hash128::hash_with_seed("hello world", [1, 2, 3, 4]), 70726204502586093039340094508598794871);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {

--- a/fasthash/src/lookup3.rs
+++ b/fasthash/src/lookup3.rs
@@ -40,7 +40,7 @@ use crate::hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 632258402);
 /// assert_eq!(Hash32::hash(b"helloworld"), 1392336737);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {

--- a/fasthash/src/metro.rs
+++ b/fasthash/src/metro.rs
@@ -56,7 +56,7 @@ use crate::hasher::FastHash;
 /// assert_eq!(Hash64_1::hash_with_seed(b"hello", 123), 1128464039211059189);
 /// assert_eq!(Hash64_1::hash(b"helloworld"), 4615394705531318333);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64_1;
 
 impl FastHash for Hash64_1 {
@@ -110,7 +110,7 @@ trivial_hasher! {
 /// assert_eq!(Hash64_2::hash_with_seed(b"hello", 123), 5558499743061241201);
 /// assert_eq!(Hash64_2::hash(b"helloworld"), 13816693401637061492);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64_2;
 
 impl FastHash for Hash64_2 {
@@ -173,7 +173,7 @@ trivial_hasher! {
 ///     168124756093089300765778527570074281113
 /// );
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128_1;
 
 impl FastHash for Hash128_1 {
@@ -236,7 +236,7 @@ trivial_hasher! {
 ///     296295343271043311657399689121923046467
 /// );
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128_2;
 
 impl FastHash for Hash128_2 {
@@ -298,7 +298,7 @@ pub mod crc {
     /// );
     /// assert_eq!(Hash64_1::hash(b"helloworld"), 15512397028293617890);
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash64_1;
 
     impl FastHash for Hash64_1 {
@@ -355,7 +355,7 @@ pub mod crc {
     /// );
     /// assert_eq!(Hash64_2::hash(b"helloworld"), 11309399771810154329);
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash64_2;
 
     impl FastHash for Hash64_2 {
@@ -418,7 +418,7 @@ pub mod crc {
     ///     330807979290440384643858402038145360287
     /// );
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash128_1;
 
     impl FastHash for Hash128_1 {
@@ -481,7 +481,7 @@ pub mod crc {
     ///     332348429832512530891646387991260171468
     /// );
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash128_2;
 
     impl FastHash for Hash128_2 {

--- a/fasthash/src/mum.rs
+++ b/fasthash/src/mum.rs
@@ -70,7 +70,7 @@ use crate::hasher::FastHash;
 /// assert_eq!(Hash64::hash_with_seed(b"hello", 123), 12693953100868515521);
 /// assert_eq!(Hash64::hash(b"helloworld"), 9122204010978352975);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {

--- a/fasthash/src/murmur.rs
+++ b/fasthash/src/murmur.rs
@@ -57,7 +57,7 @@ use crate::hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2155802495);
 /// assert_eq!(Hash32::hash(b"helloworld"), 567127608);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -106,7 +106,7 @@ trivial_hasher! {
 /// assert_eq!(Hash32Aligned::hash_with_seed(b"hello", 123), 2155802495);
 /// assert_eq!(Hash32Aligned::hash(b"helloworld"), 567127608);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32Aligned;
 
 impl FastHash for Hash32Aligned {

--- a/fasthash/src/murmur2.rs
+++ b/fasthash/src/murmur2.rs
@@ -81,7 +81,7 @@ use crate::hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2385981934);
 /// assert_eq!(Hash32::hash(b"helloworld"), 2155944146);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -130,7 +130,7 @@ trivial_hasher! {
 /// assert_eq!(Hash32A::hash_with_seed(b"hello", 123), 509510832);
 /// assert_eq!(Hash32A::hash(b"helloworld"), 403945221);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32A;
 
 impl FastHash for Hash32A {
@@ -179,7 +179,7 @@ trivial_hasher! {
 /// assert_eq!(Hash32Neutral::hash_with_seed(b"hello", 123), 2385981934);
 /// assert_eq!(Hash32Neutral::hash(b"helloworld"), 2155944146);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32Neutral;
 
 impl FastHash for Hash32Neutral {
@@ -228,7 +228,7 @@ trivial_hasher! {
 /// assert_eq!(Hash32Aligned::hash_with_seed(b"hello", 123), 2385981934);
 /// assert_eq!(Hash32Aligned::hash(b"helloworld"), 2155944146);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32Aligned;
 
 impl FastHash for Hash32Aligned {
@@ -280,7 +280,7 @@ trivial_hasher! {
 /// );
 /// assert_eq!(Hash64_x64::hash(b"helloworld"), 2139823713852166039);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64_x64;
 
 impl FastHash for Hash64_x64 {
@@ -332,7 +332,7 @@ trivial_hasher! {
 /// );
 /// assert_eq!(Hash64_x86::hash(b"helloworld"), 14017254558097603378);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64_x86;
 
 impl FastHash for Hash64_x86 {

--- a/fasthash/src/murmur3.rs
+++ b/fasthash/src/murmur3.rs
@@ -47,7 +47,7 @@ use crate::hasher::FastHash;
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 1573043710);
 /// assert_eq!(Hash32::hash(b"helloworld"), 2687965642);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -110,7 +110,7 @@ trivial_hasher! {
 ///     83212725615010754952022132390053357814
 /// );
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128_x86;
 
 impl FastHash for Hash128_x86 {
@@ -173,7 +173,7 @@ trivial_hasher! {
 ///     216280293825344914020777844322685271162
 /// );
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128_x64;
 
 impl FastHash for Hash128_x64 {

--- a/fasthash/src/sea.rs
+++ b/fasthash/src/sea.rs
@@ -45,7 +45,7 @@ use crate::hasher::{FastHash, FastHasher, StreamHasher};
 /// );
 /// assert_eq!(Hash64::hash(b"helloworld"), 9532038143498849405);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {

--- a/fasthash/src/spooky.rs
+++ b/fasthash/src/spooky.rs
@@ -63,7 +63,7 @@ use crate::hasher::{FastHash, FastHasher, HasherExt, StreamHasher};
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2211835972);
 /// assert_eq!(Hash32::hash(b"helloworld"), 3874077464);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -118,7 +118,7 @@ trivial_hasher! {
 /// assert_eq!(Hash64::hash_with_seed(b"hello", 123), 8819086853393477700);
 /// assert_eq!(Hash64::hash(b"helloworld"), 18412934266828208920);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {
@@ -182,7 +182,7 @@ trivial_hasher! {
 ///     339658686066216790682429200470429822413
 /// );
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {

--- a/fasthash/src/t1ha.rs
+++ b/fasthash/src/t1ha.rs
@@ -86,7 +86,7 @@ pub mod t1ha2 {
     ///     15302361616348747620
     /// );
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash64AtOnce;
 
     impl FastHash for Hash64AtOnce {
@@ -125,7 +125,7 @@ pub mod t1ha2 {
     ///     315212713565720527393405448145758944961
     /// );
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash128AtOnce;
 
     impl FastHash for Hash128AtOnce {
@@ -271,7 +271,7 @@ pub mod t1ha1 {
     /// );
     /// assert_eq!(Hash64Le::hash(b"helloworld"), 16997942636322422782);
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash64Le;
 
     impl FastHash for Hash64Le {
@@ -323,7 +323,7 @@ pub mod t1ha1 {
     /// );
     /// assert_eq!(Hash64Be::hash(b"helloworld"), 15825971635414726702);
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash64Be;
 
     impl FastHash for Hash64Be {
@@ -392,7 +392,7 @@ pub mod t1ha0 {
     /// );
     /// assert_eq!(Hash64::hash(b"helloworld"), 15302361616348747620);
     /// ```
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct Hash64;
 
     impl FastHash for Hash64 {

--- a/fasthash/src/xx.rs
+++ b/fasthash/src/xx.rs
@@ -47,7 +47,7 @@ use crate::hasher::{FastHash, FastHasher, StreamHasher};
 /// assert_eq!(Hash32::hash_with_seed(b"hello", 123), 2147069998);
 /// assert_eq!(Hash32::hash(b"helloworld"), 593682946);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash32;
 
 impl FastHash for Hash32 {
@@ -77,7 +77,7 @@ impl FastHash for Hash32 {
 /// assert_eq!(Hash64::hash_with_seed(b"hello", 123), 2900467397628653179);
 /// assert_eq!(Hash64::hash(b"helloworld"), 9228181307863624271);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {

--- a/fasthash/src/xxh3.rs
+++ b/fasthash/src/xxh3.rs
@@ -88,7 +88,7 @@ pub fn hash128_with_seed<T: AsRef<[u8]>>(v: T, seed: u64) -> u128 {
 /// h.write(b"world");
 /// assert_eq!(h.finish(), 5799861518677282342);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash64;
 
 impl FastHash for Hash64 {
@@ -207,7 +207,7 @@ impl_build_hasher!(Hasher64, Hash64);
 /// h.write(b"world");
 /// assert_eq!(h.finish_ext(), 235571704612606125258077068431826739245);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Hash128;
 
 impl FastHash for Hash128 {


### PR DESCRIPTION
To make `HashMap::default` work which is useful when deserializing with serde as it'll initialize the `HashMap` via `Default`.