### PR TITLE
Disable t1ha indirect functions to fix x86_64-unknown-linux-musl 

### DIFF
--- a/fasthash-sys/Cargo.toml
+++ b/fasthash-sys/Cargo.toml
@@ -19,6 +19,7 @@ sse42 = ["sse41"]
 avx = []
 avx2 = ["avx"]
 gen = ["bindgen"]
+t1ha = []
 
 [dependencies]
 cfg-if = "0.1"

--- a/fasthash-sys/build.rs
+++ b/fasthash-sys/build.rs
@@ -156,6 +156,9 @@ fn build_t1() {
         .file("src/t1ha/src/t1ha1.c")
         .file("src/t1ha/src/t1ha2.c");
 
+    // indirect functions are not supported on all targets (e.g. x86_64-unknown-linux-musl)
+    build.define("T1HA_USE_INDIRECT_FUNCTIONS", Some("0"));
+
     if support_aesni() {
         build
             .define("T1HA0_RUNTIME_SELECT", Some("1"))
@@ -225,7 +228,9 @@ fn main() {
     }
 
     build_fasthash();
-    build_t1();
+    if cfg!(feature = "t1ha") {
+        build_t1();
+    }
     build_highway();
 
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/fasthash/Cargo.toml
+++ b/fasthash/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-default = ["doc", "native"]
+default = ["doc", "native", "t1ha"]
 doc = []
 native = ["fasthash-sys/native"]
 aes = ["fasthash-sys/aes"]
@@ -20,6 +20,7 @@ sse42 = ["fasthash-sys/sse42"]
 avx = ["fasthash-sys/avx"]
 avx2 = ["fasthash-sys/avx2"]
 gen = ["fasthash-sys/gen"]
+t1ha = ["fasthash-sys/t1ha"]
 
 [dependencies]
 cfg-if = "0.1"

--- a/fasthash/benches/hash.rs
+++ b/fasthash/benches/hash.rs
@@ -125,15 +125,6 @@ fn bench_hash64(c: &mut Criterion) {
     .with_function("spooky::hash64", move |b, &&size| {
         b.iter(|| spooky::hash64_with_seed(&DATA[..size], SEED));
     })
-    .with_function("t1ha0::hash64", move |b, &&size| {
-        b.iter(|| t1ha0::Hash64::hash_with_seed(&DATA[..size], SEED));
-    })
-    .with_function("t1ha1::hash64", move |b, &&size| {
-        b.iter(|| t1ha1::Hash64::hash_with_seed(&DATA[..size], SEED));
-    })
-    .with_function("t1ha2::hash64_atonce", move |b, &&size| {
-        b.iter(|| t1ha2::Hash64AtOnce::hash_with_seed(&DATA[..size], SEED));
-    })
     .with_function("xx::hash64", move |b, &&size| {
         b.iter(|| xx::hash64_with_seed(&DATA[..size], SEED));
     })
@@ -143,6 +134,18 @@ fn bench_hash64(c: &mut Criterion) {
     .with_function("highway::hash64", move |b, &&size| {
         b.iter(|| highway::hash64_with_seed(&DATA[..size], [SEED, SEED, SEED, SEED]));
     });
+
+    #[cfg(feature = "t1ha")] {
+        bench = bench.with_function("t1ha0::hash64", move |b, &&size| {
+            b.iter(|| t1ha0::Hash64::hash_with_seed(&DATA[..size], SEED));
+        })
+            .with_function("t1ha1::hash64", move |b, &&size| {
+                b.iter(|| t1ha1::Hash64::hash_with_seed(&DATA[..size], SEED));
+            })
+            .with_function("t1ha2::hash64_atonce", move |b, &&size| {
+                b.iter(|| t1ha2::Hash64AtOnce::hash_with_seed(&DATA[..size], SEED));
+            });
+    }
 
     if cfg!(any(feature = "sse4.2", target_feature = "sse4.2")) {
         bench = bench
@@ -189,15 +192,19 @@ fn bench_hash128(c: &mut Criterion) {
     .with_function("spooky::hash128", move |b, &&size| {
         b.iter(|| spooky::hash128_with_seed(&DATA[..size], SEED as u128));
     })
-    .with_function("t1ha2::hash128_atonce", move |b, &&size| {
-        b.iter(|| t1ha2::Hash128AtOnce::hash_with_seed(&DATA[..size], SEED));
-    })
     .with_function("xxh3::hash128", move |b, &&size| {
         b.iter(|| xxh3::hash128_with_seed(&DATA[..size], SEED));
     })
     .with_function("highway::hash128", move |b, &&size| {
         b.iter(|| highway::hash128_with_seed(&DATA[..size], [SEED, SEED, SEED, SEED]));
     });
+
+    #[cfg(feature = "t1ha")] {
+        bench = bench
+            .with_function("t1ha2::hash128_atonce", move |b, &&size| {
+                b.iter(|| t1ha2::Hash128AtOnce::hash_with_seed(&DATA[..size], SEED));
+            });
+    }
 
     if cfg!(any(feature = "sse4.2", target_feature = "sse4.2")) {
         bench = bench

--- a/fasthash/src/hasher.rs
+++ b/fasthash/src/hasher.rs
@@ -566,6 +566,7 @@ mod tests {
         test_hashmap_with_hashers![murmur3::Hash32, murmur3::Hash128_x86, murmur3::Hash128_x64];
         test_hashmap_with_hashers![sea::Hash64];
         test_hashmap_with_hashers![spooky::Hash32, spooky::Hash64, spooky::Hash128];
+        #[cfg(feature = "t1ha")]
         test_hashmap_with_hashers![
             t1ha0::Hash64,
             t1ha1::Hash64Le,

--- a/fasthash/src/lib.rs
+++ b/fasthash/src/lib.rs
@@ -79,9 +79,10 @@ pub mod mum;
 pub mod murmur;
 pub mod murmur2;
 pub mod murmur3;
+#[cfg(feature = "t1ha")]
+pub mod t1ha;
 pub mod sea;
 pub mod spooky;
-pub mod t1ha;
 pub mod xx;
 pub mod xxh3;
 
@@ -97,8 +98,12 @@ pub use crate::murmur3::Hasher32 as Murmur3Hasher;
 #[doc(no_inline)]
 pub use crate::sea::Hasher64 as SeaHasher;
 pub use crate::spooky::{Hasher128 as SpookyHasherExt, Hasher64 as SpookyHasher};
-pub use crate::t1ha::{t1ha0, t1ha1, t1ha2};
-pub use crate::t1ha2::{Hasher128 as T1haHasherExt, Hasher128 as T1haHasher};
+cfg_if! {
+    if #[cfg(feature = "t1ha")] {
+        pub use crate::t1ha::{t1ha0, t1ha1, t1ha2};
+        pub use crate::t1ha2::{Hasher128 as T1haHasherExt, Hasher128 as T1haHasher};
+    }
+}
 pub use crate::xx::Hasher64 as XXHasher;
 cfg_if! {
     if #[cfg(target_pointer_width = "64")] {


### PR DESCRIPTION
The x86_64-unknown-linux-musl target currently fails to compile only due to the t1ha dependency. Truncated error message:

```
running: "x86_64-linux-musl-gcc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-static" "-Wall" "-Wextra" "-maes" "-mavx" "-mavx2" "-DT1HA0_RUNTIME_SELECT=1" "-DT1HA0_AESNI_AVAILABLE=1" "-o" "/Users/<removed>/target/x86_64-unknown-linux-musl/release/build/fasthash-sys-f1630acf3eefd1ac/out/src/t1ha/src/t1ha0.o" "-c" "src/t1ha/src/t1ha0.c"
cargo:warning=src/t1ha/src/t1ha0.c:434:10: error: ifunc is not supported on this target
cargo:warning=  434 | uint64_t t1ha0(const void *data, size_t len, uint64_t seed)
cargo:warning=      |          ^~~~~
exit code: 1
```

This is because musl does not support indirect functions (ifunc). See:

- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77894
- https://github.com/flier/pyfasthash/issues/29

This pull request does two things:

1. **Disable indirect functions by passing the -DT1HA_USE_INDIRECT_FUNCTIONS=0 flag when building t1ha** in fasthash-sys. ﻿I don’t know how to check if a target linker supports indirect functions, so this seems like the safest option for users to compile to exotic targets with neglible performance impact --- Cargo bench reports no performance regressions for the t1ha functions running locally (MacBook 2GHz Quad-Core Intel i5-1038NG7). Output of critcmp “before” and “after” the flag change:

```
group                                  after                                  before
-----                                  -----                                  ------
hash128/t1ha2::hash128_atonce/1024     1.00     92.8±0.89ns    10.3 GB/sec    1.01     94.1±1.06ns    10.1 GB/sec
hash128/t1ha2::hash128_atonce/16384    1.00  1269.0±64.16ns    12.0 GB/sec    1.05  1336.8±155.29ns    11.4 GB/sec
hash128/t1ha2::hash128_atonce/256      1.00     27.3±0.50ns     8.7 GB/sec    1.02     27.8±0.52ns     8.6 GB/sec
hash128/t1ha2::hash128_atonce/32       1.00     12.0±0.11ns     2.5 GB/sec    1.07     12.8±2.01ns     2.3 GB/sec
hash128/t1ha2::hash128_atonce/4096     1.00    325.9±2.32ns    11.7 GB/sec    1.03   335.6±18.81ns    11.4 GB/sec
hash128/t1ha2::hash128_atonce/7        1.00     10.2±0.13ns   653.3 MB/sec    1.01     10.4±0.24ns   644.7 MB/sec
hash128/t1ha2::hash128_atonce/8        1.00      9.4±0.10ns   807.7 MB/sec    1.02      9.6±0.16ns   795.2 MB/sec
hash64/t1ha0::hash64/1024              1.00     20.1±0.44ns    47.4 GB/sec    1.01     20.2±1.33ns    47.2 GB/sec
hash64/t1ha0::hash64/16384             1.00    225.2±2.66ns    67.7 GB/sec    1.00    225.0±3.86ns    67.8 GB/sec
hash64/t1ha0::hash64/256               1.00     10.2±0.14ns    23.3 GB/sec    1.00     10.2±0.19ns    23.3 GB/sec
hash64/t1ha0::hash64/32                1.00      7.5±0.13ns     4.0 GB/sec    1.00      7.5±0.09ns     4.0 GB/sec
hash64/t1ha0::hash64/4096              1.00     66.7±3.66ns    57.2 GB/sec    1.00     66.7±1.07ns    57.2 GB/sec
hash64/t1ha0::hash64/7                 1.00      5.9±0.07ns  1131.4 MB/sec    1.00      5.9±0.07ns  1128.4 MB/sec
hash64/t1ha0::hash64/8                 1.00      5.5±0.07ns  1399.7 MB/sec    1.00      5.5±0.08ns  1397.9 MB/sec
hash64/t1ha1::hash64/1024              1.00     90.6±1.06ns    10.5 GB/sec    1.00     90.3±0.89ns    10.6 GB/sec
hash64/t1ha1::hash64/16384             1.00  1264.4±14.17ns    12.1 GB/sec    1.03  1300.5±151.07ns    11.7 GB/sec
hash64/t1ha1::hash64/256               1.00     24.8±0.36ns     9.6 GB/sec    0.99     24.6±0.48ns     9.7 GB/sec
hash64/t1ha1::hash64/32                1.00      6.0±0.10ns     4.9 GB/sec    1.00      6.0±0.07ns     5.0 GB/sec
hash64/t1ha1::hash64/4096              1.00    326.2±4.39ns    11.7 GB/sec    1.00    325.0±4.67ns    11.7 GB/sec
hash64/t1ha1::hash64/7                 1.00      4.9±0.06ns  1361.2 MB/sec    1.00      4.9±0.05ns  1360.5 MB/sec
hash64/t1ha1::hash64/8                 1.00      4.5±0.07ns  1680.3 MB/sec    1.00      4.5±0.06ns  1682.6 MB/sec
hash64/t1ha2::hash64_atonce/1024       1.00     91.0±1.71ns    10.5 GB/sec    1.01     92.3±1.88ns    10.3 GB/sec
hash64/t1ha2::hash64_atonce/16384      1.00  1263.0±19.33ns    12.1 GB/sec    1.03  1304.2±56.13ns    11.7 GB/sec
hash64/t1ha2::hash64_atonce/256        1.00     24.5±0.37ns     9.7 GB/sec    1.00     24.5±0.30ns     9.7 GB/sec
hash64/t1ha2::hash64_atonce/32         1.00      6.8±0.12ns     4.4 GB/sec    1.01      6.9±0.13ns     4.3 GB/sec
hash64/t1ha2::hash64_atonce/4096       1.00    325.0±5.15ns    11.7 GB/sec    1.03   334.1±10.68ns    11.4 GB/sec
hash64/t1ha2::hash64_atonce/7          1.00      5.0±0.11ns  1331.4 MB/sec    1.02      5.1±0.27ns  1299.0 MB/sec
hash64/t1ha2::hash64_atonce/8          1.00      4.6±0.08ns  1659.4 MB/sec    1.01      4.7±0.07ns  1639.0 MB/sec
```

2. **Make t1ha a default feature in Cargo.toml**, so users can disable it if not in use to improve compilation times and reduce build sizes:

- **with t1ha: 19.20s/23M**
```
cargo build —release:
23M    ../target/release
Finished release [optimized] target(s) in 19.20s
```

- **without t1ha: 15.78s/19M**
```
cargo build —release —no-default-features —features=“doc native":
19M    ../target/release
Finished release [optimized] target(s) in 15.78s
```

The default features are now:

```
[features]
default = ["doc", "native", "t1ha”]
```

So users who do not want t1ha can specify in their Cargo.toml:

```
fasthash = { version = “0.4", default-features = false, features = [“doc”, "native"] }
```

N.B. the flag change seems sufficient to build on musl without removing the t1ha feature, so t1ha hash functions can still be used. I have successfully cross-compiled to the x86_64-unknown-linux-musl target with and without t1ha on MacOS using https://github.com/FiloSottile/homebrew-musl-cross

This should resolve issue #9 and work towards fixing compilation on Windows from #11. There are no changes to functionality so it is safe to release this as a patch version.
